### PR TITLE
Add multipart form support and file library

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@
 - Cacheo de respuestas en Redis mediante decoradores.
 - Migraciones de base de datos con TypeORM CLI.
 - Dockerfile y docker-compose para ambiente local.
+- Soporte para formularios multipart/form-data y subida de archivos.
 
 ---
 

--- a/src/app/modules/users/services/business-unit.service.ts
+++ b/src/app/modules/users/services/business-unit.service.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from "express";
 import { requestHandler } from "@core/bases/base.services";
 import { Cacheable } from "@libs/cacheable";
+import { saveFile } from "@libs/file";
 
 import BusinessUnit from "../domain/models/business-unit";
 import businessUnitRepository from "../infrastructure/repositories/business-unit.repository";
@@ -22,6 +23,10 @@ export default class BusinessUnitService {
 
   @requestHandler
   static async businessUnitRegister(this: void, req: Request, res: Response, next: NextFunction) {
+    if (req.files && req.files['businessUnitLogo']) {
+      const path = await saveFile(req.files['businessUnitLogo'], 'public/uploads');
+      (req.body as any).businessUnitLogo = path.replace(/^public\//, '');
+    }
     const businessUnit = new BusinessUnit(req.body);
     const result = await businessUnitRepository.createBusinessUnitOrUpdate(businessUnit);
     return result;
@@ -29,6 +34,10 @@ export default class BusinessUnitService {
 
   @requestHandler
   static async businessUnitUpdate(this: void, req: Request, res: Response, next: NextFunction) {
+    if (req.files && req.files['businessUnitLogo']) {
+      const path = await saveFile(req.files['businessUnitLogo'], 'public/uploads');
+      (req.body as any).businessUnitLogo = path.replace(/^public\//, '');
+    }
     const businessUnit = new BusinessUnit(req.body);
     const result = await businessUnitRepository.createBusinessUnitOrUpdate(businessUnit);
     return result;

--- a/src/common/libs/file.ts
+++ b/src/common/libs/file.ts
@@ -1,0 +1,20 @@
+export interface UploadedFile {
+  buffer: Buffer;
+  originalname: string;
+  mimetype: string;
+}
+
+import fs from 'fs-extra';
+import path from 'path';
+
+/**
+ * Save an uploaded file buffer to the specified folder.
+ * The returned path is relative to the project root.
+ */
+export async function saveFile(file: UploadedFile, folder: string): Promise<string> {
+  await fs.ensureDir(folder);
+  const filename = `${Date.now()}_${file.originalname}`;
+  const filePath = path.join(folder, filename);
+  await fs.writeFile(filePath, file.buffer);
+  return filePath;
+}

--- a/src/common/middlewares/multipart.middleware.ts
+++ b/src/common/middlewares/multipart.middleware.ts
@@ -1,0 +1,41 @@
+import { Request, Response, NextFunction } from 'express';
+import getRawBody from 'raw-body';
+
+// Very small multipart parser supporting basic form data and single file fields
+export default async function multipartMiddleware(req: Request, res: Response, next: NextFunction) {
+  const type = req.headers['content-type'];
+  if (type && type.includes('multipart/form-data')) {
+    const match = type.match(/boundary=(?:(?:"([^\"]+)")|([^;]+))/);
+    if (!match) {
+      return next();
+    }
+    const boundary = match[1] || match[2];
+    const bodyBuffer = await getRawBody(req);
+    const parts = bodyBuffer.toString('binary').split(`--${boundary}`);
+    req.body = {};
+    (req as any).files = {};
+    for (const part of parts) {
+      if (!part || part === '--\r\n' || part === '--' || part === '\r\n') continue;
+      const [head, ...rest] = part.split('\r\n\r\n');
+      if (!head || !rest.length) continue;
+      const content = rest.join('\r\n\r\n');
+      const headers = head.split('\r\n').filter(Boolean);
+      const disposition = headers.find(h => h.toLowerCase().startsWith('content-disposition'));
+      if (!disposition) continue;
+      const nameMatch = disposition.match(/name="([^"]+)"/);
+      if (!nameMatch) continue;
+      const fieldName = nameMatch[1];
+      const filenameMatch = disposition.match(/filename="([^"]*)"/);
+      const value = content.replace(/\r\n--$/, '').replace(/\r\n$/, '');
+      if (filenameMatch && filenameMatch[1]) {
+        const mimeHeader = headers.find(h => h.toLowerCase().startsWith('content-type'));
+        const mimetype = mimeHeader ? mimeHeader.split(':')[1].trim() : 'application/octet-stream';
+        const buffer = Buffer.from(value, 'binary');
+        (req as any).files[fieldName] = { buffer, originalname: filenameMatch[1], mimetype };
+      } else {
+        req.body[fieldName] = value;
+      }
+    }
+  }
+  next();
+}

--- a/src/config/server.ts
+++ b/src/config/server.ts
@@ -8,6 +8,7 @@ import notFoundMiddleware from "@middlewares/404.middleware";
 import authMiddleware from "@middlewares/jwt.middleware";
 import loggerMiddleware from "@middlewares/logger.middleware";
 import cleanUndefinedQueryMiddleware from "@middlewares/clean.middleware";
+import multipartMiddleware from "@middlewares/multipart.middleware";
 
 dotenv.config();
 
@@ -25,7 +26,9 @@ export class ServerExpress {
   private initializeMiddlewares() {
     this.app.use(corsConfig);
     this.app.use(express.json());
+    this.app.use(express.urlencoded({ extended: true }));
     this.app.use(express.static("public"));
+    this.app.use(multipartMiddleware);
     this.app.use(loggerMiddleware);
     this.app.use(cleanUndefinedQueryMiddleware);
     this.app.use(responseMiddleware);

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,0 +1,8 @@
+import 'express-serve-static-core';
+import { UploadedFile } from '../common/libs/file';
+
+declare module 'express-serve-static-core' {
+  interface Request {
+    files?: Record<string, UploadedFile>;
+  }
+}


### PR DESCRIPTION
## Summary
- parse `multipart/form-data` with a lightweight middleware
- expose uploaded files on the request type
- add helper to save uploaded files
- persist uploaded business unit logo using new helper
- enable URL encoded bodies and new middleware in the server
- document new file upload capability

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685b478fea808330b4f33bb6cf676779