### PR TITLE
Add cache invalidation decorator and rename request handler

### DIFF
--- a/src/app/core/bases/base.services.ts
+++ b/src/app/core/bases/base.services.ts
@@ -8,7 +8,7 @@ export function customErrorHandler(
   throw { message, statusCode };
 }
 
-export function requestHandler(
+export function RequestHandler(
   _target: any,
   _propertyKey: string,
   descriptor: PropertyDescriptor

--- a/src/app/modules/files/services/file.service.ts
+++ b/src/app/modules/files/services/file.service.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { requestHandler } from '@core/bases/base.services';
+import { RequestHandler } from '@core/bases/base.services';
 
 interface UploadedFileInfo {
   originalname: string;
@@ -7,7 +7,7 @@ interface UploadedFileInfo {
 }
 
 export default class FileService {
-  @requestHandler
+  @RequestHandler
   static async upload(
     this: void,
     req: Request,

--- a/src/app/modules/users/services/business-unit.service.ts
+++ b/src/app/modules/users/services/business-unit.service.ts
@@ -1,33 +1,35 @@
 import { Request, Response, NextFunction } from "express";
-import { requestHandler } from "@core/bases/base.services";
-import { Cacheable } from "@libs/cacheable";
+import { RequestHandler } from "@core/bases/base.services";
+import { Cacheable, InvalidateCache } from "@libs/cacheable";
 
 import BusinessUnit from "../domain/models/business-unit";
 import businessUnitRepository from "../infrastructure/repositories/business-unit.repository";
 
 export default class BusinessUnitService {
-  @requestHandler
+  @RequestHandler
   @Cacheable({ keyPrefix: "businessUnits", ttl: 60 })
   static async getBusinessUnits(this: void, req: Request, res: Response, next: NextFunction) {
     const { data, total } = await businessUnitRepository.getBusinessUnitsByParams(req.query);
     return { data, total };
   }
 
-  @requestHandler
+  @RequestHandler
   @Cacheable({ keyPrefix: "businessUnit", idParam: "businessUnitId", ttl: 60 })
   static async getOneBusinessUnit(this: void, req: Request, res: Response, next: NextFunction) {
     const businessUnit = await businessUnitRepository.getOneBusinessUnitByParams(req.query);
     return businessUnit;
   }
 
-  @requestHandler
+  @RequestHandler
+  @InvalidateCache({ keys: ['businessUnits'] })
   static async businessUnitRegister(this: void, req: Request, res: Response, next: NextFunction) {
     const businessUnit = new BusinessUnit(req.body);
     const result = await businessUnitRepository.createBusinessUnitOrUpdate(businessUnit);
     return result;
   }
 
-  @requestHandler
+  @RequestHandler
+  @InvalidateCache({ keys: (req: Request) => ['businessUnits', `businessUnit:${req.body.businessUnitId}`] })
   static async businessUnitUpdate(this: void, req: Request, res: Response, next: NextFunction) {
     const businessUnit = new BusinessUnit(req.body);
     const result = await businessUnitRepository.createBusinessUnitOrUpdate(businessUnit);

--- a/src/app/modules/users/services/role.service.ts
+++ b/src/app/modules/users/services/role.service.ts
@@ -1,47 +1,50 @@
 import { Request, Response, NextFunction } from "express";
-import { requestHandler } from "@core/bases/base.services";
-import { Cacheable } from "@libs/cacheable";
+import { RequestHandler } from "@core/bases/base.services";
+import { Cacheable, InvalidateCache } from "@libs/cacheable";
 
 import Role from "../domain/models/role";
 import roleRepository from "../infrastructure/repositories/role.repository";
 
 export default class RoleService {
-  @requestHandler
+  @RequestHandler
   @Cacheable({ keyPrefix: "roles", ttl: 60 })
   static async getRoles(this: void, req: Request, res: Response, next: NextFunction) {
     const { data, total } = await roleRepository.getRolesByParams(req.query);
     return { data, total };
   }
 
-  @requestHandler
+  @RequestHandler
   @Cacheable({ keyPrefix: "role", idParam: "roleId", ttl: 60 })
   static async getOneRole(this: void, req: Request, res: Response, next: NextFunction) {
     const role = await roleRepository.getOneRoleByParams(req.query);
     return role;
   }
 
-  @requestHandler
+  @RequestHandler
+  @InvalidateCache({ keys: ['roles'] })
   static async roleRegister(this: void, req: Request, res: Response, next: NextFunction) {
     const role = new Role(req.body);
     const result = await roleRepository.createRoleOrUpdate(role);
     return result;
   }
 
-  @requestHandler
+  @RequestHandler
   @Cacheable({ keyPrefix: "permissions", ttl: 60 })
   static async getPermissions(this: void, _req: Request, res: Response, next: NextFunction) {
     const result = await roleRepository.getPermissions();
     return result;
   }
 
-  @requestHandler
+  @RequestHandler
+  @InvalidateCache({ keys: ['roles'] })
   static async addPermissionToRole(this: void, req: Request, res: Response, next: NextFunction) {
     const role = new Role(req.body);
     const result = await roleRepository.addPermissionToRole(role);
     return result;
   }
 
-  @requestHandler
+  @RequestHandler
+  @InvalidateCache({ keys: (req: Request) => ['roles', `role:${req.body.roleId}`] })
   static async roleUpdate(this: void, req: Request, res: Response, next: NextFunction) {
     const role = new Role(req.body);
     const result = await roleRepository.createRoleOrUpdate(role);

--- a/src/app/modules/users/services/session.service.ts
+++ b/src/app/modules/users/services/session.service.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from "express";
-import { requestHandler } from "@core/bases/base.services";
-import { Cacheable } from "@libs/cacheable";
+import { RequestHandler } from "@core/bases/base.services";
+import { Cacheable, InvalidateCache } from "@libs/cacheable";
 
 import UserSession from "../domain/models/user-session";
 import userSessionRepository from "../infrastructure/repositories/user-session.repository";
@@ -8,7 +8,7 @@ import userSessionRepository from "../infrastructure/repositories/user-session.r
 import { addHours } from "date-fns";
 
 export default class SessionService {
-  @requestHandler
+  @RequestHandler
   @Cacheable({ keyPrefix: "sessions", ttl: 60 })
   static async getSessions(
     this: void,
@@ -20,7 +20,7 @@ export default class SessionService {
     return { data, total };
   }
 
-  @requestHandler
+  @RequestHandler
   @Cacheable({ keyPrefix: "session", idParam: "userId", ttl: 60 })
   static async getOneUser(
     this: void,
@@ -32,7 +32,8 @@ export default class SessionService {
     return session;
   }
 
-  @requestHandler
+  @RequestHandler
+  @InvalidateCache({ keys: (req: Request) => ['sessions', `session:${req.body.userId}`] })
   static async closeSession(
     this: void,
     req: Request,
@@ -46,7 +47,8 @@ export default class SessionService {
     return session;
   }
 
-  @requestHandler
+  @RequestHandler
+  @InvalidateCache({ keys: ['sessions'] })
   static async closeOneSession(
     this: void,
     req: Request,
@@ -60,7 +62,8 @@ export default class SessionService {
     return;
   }
 
-  @requestHandler
+  @RequestHandler
+  @InvalidateCache({ keys: (req: Request) => ['sessions', `session:${req.body.userId}`] })
   static async banSession(
     this: void,
     req: Request,

--- a/src/app/modules/users/services/user.service.ts
+++ b/src/app/modules/users/services/user.service.ts
@@ -1,6 +1,6 @@
 import { Request, Response, NextFunction } from "express";
-import { requestHandler, customErrorHandler } from "@core/bases/base.services";
-import { Cacheable } from "@libs/cacheable";
+import { RequestHandler, customErrorHandler } from "@core/bases/base.services";
+import { Cacheable, InvalidateCache } from "@libs/cacheable";
 
 import User from "../domain/models/user";
 import userRepository from "../infrastructure/repositories/user.repository";
@@ -12,7 +12,7 @@ import { hashPassword, comparePassword } from "@libs/bcrypt";
 import { generateToken } from "@libs/token";
 
 export default class UserService {
-  @requestHandler
+  @RequestHandler
   @Cacheable({ keyPrefix: "users", ttl: 60 })
   static async getUser(
     this: void,
@@ -24,7 +24,7 @@ export default class UserService {
     return { data, total };
   }
 
-  @requestHandler
+  @RequestHandler
   @Cacheable({ keyPrefix: "user", idParam: "userId", ttl: 60 })
   static async getOneUser(
     this: void,
@@ -36,7 +36,8 @@ export default class UserService {
     return user;
   }
 
-  @requestHandler
+  @RequestHandler
+  @InvalidateCache({ keys: ['users'] })
   static async userRegister(
     this: void,
     req: Request,
@@ -51,7 +52,8 @@ export default class UserService {
     return { message: "Usuario creado con éxito" };
   }
 
-  @requestHandler
+  @RequestHandler
+  @InvalidateCache({ keys: (req: Request) => ['users', `user:${req.body.userId}`] })
   static async userUpdate(
     this: void,
     req: Request,
@@ -66,7 +68,7 @@ export default class UserService {
     return { message: "Se actualizo el usuario correctamente." };
   }
 
-  @requestHandler
+  @RequestHandler
   static async login(
     this: void,
     req: Request,
@@ -96,7 +98,8 @@ export default class UserService {
     return { ...user, token };
   }
 
-  @requestHandler
+  @RequestHandler
+  @InvalidateCache({ keys: (req: Request) => ['users', `user:${req.body.userId}`] })
   static async updateBusinessUnitsToUser(
     this: void,
     req: Request,


### PR DESCRIPTION
## Summary
- add `InvalidateCache` decorator beside `Cacheable`
- rename `requestHandler` decorator to `RequestHandler`
- clear redis caches after create/update methods for users, business units, roles and sessions
- update file service to use renamed decorator

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685b69bdfd608330891de857da05d103