### PR TITLE
Add file saving util

### DIFF
--- a/src/app/modules/files/services/file.service.ts
+++ b/src/app/modules/files/services/file.service.ts
@@ -1,11 +1,8 @@
 import { Request, Response, NextFunction } from 'express';
 import { RequestHandler } from '@core/bases/base.services';
+import { FileBuffer, saveFile } from '@libs/file';
 
-interface UploadedFileInfo {
-  originalname: string;
-  path: string;
-}
-
+interface UploadedFileInfo extends FileBuffer {}
 export default class FileService {
   @RequestHandler
   static async upload(
@@ -18,6 +15,13 @@ export default class FileService {
     if (!files || files.length === 0) {
       throw { message: 'Archivo no proporcionado', statusCode: 400 };
     }
-    return { files };
+
+    const saved = [] as { originalname: string; path: string }[];
+    for (const file of files) {
+      const filePath = await saveFile(file);
+      saved.push({ originalname: file.originalname, path: filePath });
+    }
+
+    return { files: saved };
   }
 }

--- a/src/common/libs/file.ts
+++ b/src/common/libs/file.ts
@@ -1,0 +1,20 @@
+import fs from 'fs-extra';
+import path from 'path';
+
+const DEFAULT_DIR = path.join(process.cwd(), 'public', 'uploads');
+
+export interface FileBuffer {
+  originalname: string;
+  buffer: Buffer;
+}
+
+export async function saveFile(
+  file: FileBuffer,
+  dir: string = DEFAULT_DIR
+): Promise<string> {
+  await fs.ensureDir(dir);
+  const storedName = `${Date.now()}-${file.originalname}`;
+  const filePath = path.join(dir, storedName);
+  await fs.writeFile(filePath, file.buffer);
+  return filePath;
+}

--- a/src/common/middlewares/multipart.middleware.ts
+++ b/src/common/middlewares/multipart.middleware.ts
@@ -1,8 +1,5 @@
 import { RequestHandler } from 'express';
-import fs from 'fs';
 import path from 'path';
-
-const UPLOAD_DIR = path.join(process.cwd(), 'public', 'uploads');
 
 const multipartMiddleware: RequestHandler = (req, res, next) => {
   const contentType = req.headers['content-type'];
@@ -42,12 +39,8 @@ const multipartMiddleware: RequestHandler = (req, res, next) => {
       if (filenameMatch && filenameMatch[1]) {
         const filename = path.basename(filenameMatch[1]);
         const fileBuffer = Buffer.from(data, 'binary');
-        fs.mkdirSync(UPLOAD_DIR, { recursive: true });
-        const storedName = `${Date.now()}-${filename}`;
-        const filePath = path.join(UPLOAD_DIR, storedName);
-        fs.writeFileSync(filePath, fileBuffer);
-        (req as any).files.push({ originalname: filename, path: filePath });
-        (req.body as any)[name] = storedName;
+        (req as any).files.push({ originalname: filename, buffer: fileBuffer });
+        (req.body as any)[name] = filename;
       } else {
         (req.body as any)[name] = data;
       }

--- a/src/types/express/index.d.ts
+++ b/src/types/express/index.d.ts
@@ -2,6 +2,6 @@ import 'express-serve-static-core';
 
 declare module 'express-serve-static-core' {
   interface Request {
-    files?: { originalname: string; path: string }[];
+    files?: { originalname: string; buffer: Buffer }[];
   }
 }


### PR DESCRIPTION
## Summary
- change multipart middleware to keep buffers in memory
- create a helper to save files on demand
- wire the upload service to use `saveFile`
- update Express types for new file buffer structure

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685b70bba7808330ab25a326d56b4f8b