### PR TITLE
Add storage products module

### DIFF
--- a/src/app/modules/storage/domain/models/product.ts
+++ b/src/app/modules/storage/domain/models/product.ts
@@ -1,0 +1,37 @@
+import { Expose, Type, plainToInstance, instanceToPlain } from 'class-transformer';
+
+import User from '@modules/users/domain/models/user';
+import BusinessUnit from '@modules/users/domain/models/business-unit';
+
+export type TYPE = 'ALMACEN' | 'SERVICIO';
+export type STATUS = 'ACTIVO' | 'ELIMINADO' | 'AGOTADO';
+
+export default class Product {
+  @Expose() productId?: number;
+  @Expose() productName?: string;
+  @Expose() productImage?: string;
+  @Expose() type?: TYPE;
+  @Expose() stock?: number;
+  @Expose() status?: STATUS;
+  @Expose() createdAt?: string;
+  @Expose() updatedAt?: string;
+
+  @Type(() => User)
+  @Expose()
+  createdBy?: User;
+
+  @Type(() => BusinessUnit)
+  @Expose()
+  businessUnit?: BusinessUnit;
+
+  constructor(data: Partial<Product>) {
+    return plainToInstance(Product, data, { excludeExtraneousValues: true });
+  }
+
+  toJSON() {
+    return Object.fromEntries(
+      Object.entries(instanceToPlain(this, { exposeUnsetFields: false }))
+        .filter(([_, v]) => v !== null && v !== undefined)
+    );
+  }
+}

--- a/src/app/modules/storage/domain/validator/product.validator.ts
+++ b/src/app/modules/storage/domain/validator/product.validator.ts
@@ -1,0 +1,28 @@
+import { body } from 'express-validator';
+import productRepository from '../../infrastructure/repositories/product.repository';
+
+const existProduct = async (productId: number) => {
+  const product = await productRepository.getOneProductByParams({ productId });
+  if (!product) {
+    throw new Error('El producto no existe.');
+  }
+};
+
+export const createProductSchema = [
+  body('productName')
+    .notEmpty().withMessage('El nombre es requerido.')
+    .isString().withMessage('El nombre debe ser una cadena de texto.'),
+  body('type')
+    .notEmpty().withMessage('El tipo es requerido.')
+    .isIn(['ALMACEN', 'SERVICIO']).withMessage('Tipo no válido.'),
+  body('stock')
+    .notEmpty().withMessage('El stock es requerido.')
+    .isNumeric().withMessage('El stock debe ser numérico.')
+];
+
+export const updateProductSchema = [
+  body('productId')
+    .notEmpty().withMessage('El id es requerido.')
+    .isNumeric().withMessage('El id debe ser un número.')
+    .custom(existProduct).withMessage('El producto no existe.')
+];

--- a/src/app/modules/storage/infrastructure/entities/product.entity.ts
+++ b/src/app/modules/storage/infrastructure/entities/product.entity.ts
@@ -1,0 +1,47 @@
+import { Column, CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
+import { UserEntity } from '@modules/users/infrastructure/entities/user.entity';
+import { BusinessUnitEntity } from '@modules/users/infrastructure/entities/business-unit.entity';
+
+export enum TYPE {
+  ALMACEN = 'ALMACEN',
+  SERVICIO = 'SERVICIO'
+}
+
+export enum STATUS {
+  ACTIVO = 'ACTIVO',
+  ELIMINADO = 'ELIMINADO',
+  AGOTADO = 'AGOTADO'
+}
+
+@Entity('products')
+export class ProductEntity {
+  @PrimaryGeneratedColumn()
+  productId!: number;
+
+  @Column({ length: 128 })
+  productName!: string;
+
+  @Column({ length: 512 })
+  productImage!: string;
+
+  @Column({ type: 'enum', enum: TYPE })
+  type!: string;
+
+  @Column('int')
+  stock!: number;
+
+  @Column({ type: 'enum', enum: STATUS, default: STATUS.ACTIVO })
+  status!: string;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
+
+  @ManyToOne(() => UserEntity, user => user.products, { eager: true })
+  createdBy!: UserEntity;
+
+  @ManyToOne(() => BusinessUnitEntity, bu => bu.products, { eager: true })
+  businessUnit!: BusinessUnitEntity;
+}

--- a/src/app/modules/storage/infrastructure/repositories/product.repository.ts
+++ b/src/app/modules/storage/infrastructure/repositories/product.repository.ts
@@ -1,0 +1,50 @@
+import Product from '../../domain/models/product';
+import { ProductEntity } from '../entities/product.entity';
+
+import { BaseRepository } from '@app/core/bases/base.repository';
+import { ResponseInterface } from '@app/core/interfaces';
+
+class ProductRepository extends BaseRepository<ProductEntity> {
+  constructor() { super(ProductEntity, 'product'); }
+
+  async getProductsByParams(params: Record<string, any>): Promise<ResponseInterface<ProductEntity>> {
+    const { page, limit, orderBy, ...filters } = params;
+
+    this.joinConfig = {
+      createdBy: 'left',
+      businessUnit: 'left'
+    };
+
+    return this.findAllByParams({
+      filters,
+      page,
+      limit,
+      orderBy,
+      forceJoins: ['createdBy', 'businessUnit']
+    });
+  }
+
+  async getOneProductByParams(filters: Record<string, any>): Promise<ProductEntity | null> {
+    this.joinConfig = {
+      createdBy: 'left',
+      businessUnit: 'left'
+    };
+
+    return this.findOneByParams({
+      filters,
+      forceJoins: ['createdBy', 'businessUnit']
+    });
+  }
+
+  async createOrUpdateProduct(product: Product): Promise<ProductEntity> {
+    const { createdBy, businessUnit, ...params } = product.toJSON();
+    return await this.repository.save({
+      ...params,
+      createdBy: createdBy?.userId ? { userId: createdBy.userId } : undefined,
+      businessUnit: businessUnit?.businessUnitId ? { businessUnitId: businessUnit.businessUnitId } : undefined
+    });
+  }
+}
+
+const productRepository = new ProductRepository();
+export default productRepository;

--- a/src/app/modules/storage/services/product.service.ts
+++ b/src/app/modules/storage/services/product.service.ts
@@ -1,0 +1,48 @@
+import { Request, Response, NextFunction } from 'express';
+import { RequestHandler } from '@core/bases/base.services';
+import { Cacheable, InvalidateCache } from '@libs/cacheable';
+
+import Product from '../domain/models/product';
+import productRepository from '../infrastructure/repositories/product.repository';
+
+export default class ProductService {
+  @RequestHandler
+  @Cacheable({ keyPrefix: 'products', ttl: 60 })
+  static async getProducts(this: void, req: Request, res: Response, next: NextFunction) {
+    const { data, total } = await productRepository.getProductsByParams(req.query);
+    return { data, total };
+  }
+
+  @RequestHandler
+  @Cacheable({ keyPrefix: 'product', idParam: 'productId', ttl: 60 })
+  static async getOneProduct(this: void, req: Request, res: Response, next: NextFunction) {
+    const product = await productRepository.getOneProductByParams(req.query);
+    return product;
+  }
+
+  @RequestHandler
+  @InvalidateCache({ keys: ['products'] })
+  static async productRegister(this: void, req: Request, res: Response, next: NextFunction) {
+    const [file] = (req as any).files as { originalname: string; buffer: Buffer }[] || [];
+    const product = new Product(req.body);
+    if (file) {
+      const { saveFile } = await import('@libs/file');
+      product.productImage = await saveFile(file);
+    }
+    const result = await productRepository.createOrUpdateProduct(product);
+    return result;
+  }
+
+  @RequestHandler
+  @InvalidateCache({ keys: (req: Request) => ['products', `product:${req.body.productId}`] })
+  static async productUpdate(this: void, req: Request, res: Response, next: NextFunction) {
+    const [file] = (req as any).files as { originalname: string; buffer: Buffer }[] || [];
+    const product = new Product(req.body);
+    if (file) {
+      const { saveFile } = await import('@libs/file');
+      product.productImage = await saveFile(file);
+    }
+    const result = await productRepository.createOrUpdateProduct(product);
+    return result;
+  }
+}

--- a/src/app/modules/users/infrastructure/entities/business-unit.entity.ts
+++ b/src/app/modules/users/infrastructure/entities/business-unit.entity.ts
@@ -1,6 +1,7 @@
-import { Column, CreateDateColumn, Entity, JoinColumn, ManyToMany, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
+import { Column, CreateDateColumn, Entity, JoinColumn, ManyToMany, OneToMany, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
 
 import { UserEntity } from "./user.entity";
+import { ProductEntity } from "@modules/storage/infrastructure/entities/product.entity";
 
 export enum STATUS {
   ACTIVO = "ACTIVO",
@@ -30,4 +31,7 @@ export class BusinessUnitEntity {
 
   @ManyToMany(() => UserEntity, user => user.businessUnits)
   users?: UserEntity[];
+
+  @OneToMany(() => ProductEntity, product => product.businessUnit)
+  products?: ProductEntity[];
 }

--- a/src/app/modules/users/infrastructure/entities/user.entity.ts
+++ b/src/app/modules/users/infrastructure/entities/user.entity.ts
@@ -4,6 +4,7 @@ import { PersonEntity } from "./person.entity";
 import { RoleEntity } from "./role.entity";
 import { UserSessionEntity } from "./user-session.entity";
 import { BusinessUnitEntity } from "./business-unit.entity";
+import { ProductEntity } from "@modules/storage/infrastructure/entities/product.entity";
 
 export enum STATUS {
   ACTIVO = "ACTIVO",
@@ -67,5 +68,8 @@ export class UserEntity {
     }
   })
   businessUnits?: BusinessUnitEntity[];
+
+  @OneToMany(() => ProductEntity, product => product.createdBy)
+  products?: ProductEntity[];
 
 }

--- a/src/app/routes/administration/index.ts
+++ b/src/app/routes/administration/index.ts
@@ -5,6 +5,7 @@ import roleRouter from "./role.routes";
 import sectionRouter from "./section.routes";
 import menuRouter from "./menu.routes";
 import businessUnitRouter from "./business-unit.routes";
+import productRouter from "./product.routes";
 
 const administrationRouter = Router();
 
@@ -13,5 +14,6 @@ administrationRouter.use("/roles", roleRouter);
 administrationRouter.use("/sections", sectionRouter);
 administrationRouter.use("/menus", menuRouter);
 administrationRouter.use("/business-units", businessUnitRouter);
+administrationRouter.use("/products", productRouter);
 
 export default administrationRouter;

--- a/src/app/routes/administration/product.routes.ts
+++ b/src/app/routes/administration/product.routes.ts
@@ -1,0 +1,15 @@
+import { Router } from 'express';
+import { validate } from '@middlewares/validator.middleware';
+import multipartMiddleware from '@middlewares/multipart.middleware';
+
+import ProductService from '@modules/storage/services/product.service';
+import { createProductSchema, updateProductSchema } from '@modules/storage/domain/validator/product.validator';
+
+const productRouter = Router();
+
+productRouter.get('/', ProductService.getProducts as any);
+productRouter.get('/unique', ProductService.getOneProduct as any);
+productRouter.post('/', multipartMiddleware, validate(createProductSchema), ProductService.productRegister as any);
+productRouter.put('/', multipartMiddleware, validate(updateProductSchema), ProductService.productUpdate as any);
+
+export default productRouter;


### PR DESCRIPTION
## Summary
- introduce new `storage` module with CRUD for products
- products belong to business units and are created by users
- expose `/api/administration/products` routes
- extend user and business unit entities with relations to products

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685b826ad2808330ace1c5eff391f181