### PR TITLE
Add cut-off entity to storage module

### DIFF
--- a/src/app/modules/storage/domain/models/cut-off.ts
+++ b/src/app/modules/storage/domain/models/cut-off.ts
@@ -1,0 +1,27 @@
+import { Expose, plainToInstance, instanceToPlain, Type } from 'class-transformer';
+import User from '@app/modules/users/domain/models/user';
+
+export type STATUS = 'ACTIVO' | 'ELIMINADO';
+
+export default class CutOff {
+  @Expose() cutOffId?: number;
+  @Type(() => User)
+  @Expose() user?: User;
+  @Expose() totalEntries?: number;
+  @Expose() totalOutputs?: number;
+  @Expose() totalCash?: number;
+  @Expose() cutoffDate?: string;
+  @Expose() status?: STATUS;
+  @Expose() createdAt?: string;
+
+  constructor(data: Partial<CutOff>) {
+    return plainToInstance(CutOff, data, { excludeExtraneousValues: true });
+  }
+
+  toJSON() {
+    return Object.fromEntries(
+      Object.entries(instanceToPlain(this, { exposeUnsetFields: false }))
+        .filter(([_, v]) => v !== null && v !== undefined)
+    );
+  }
+}

--- a/src/app/modules/storage/domain/validator/cut-off.validator.ts
+++ b/src/app/modules/storage/domain/validator/cut-off.validator.ts
@@ -1,0 +1,31 @@
+import { body } from 'express-validator';
+import cutOffRepository from '../../infrastructure/repositories/cut-off.repository';
+
+const existCutOff = async (cutOffId: number) => {
+  const cutOff = await cutOffRepository.getOneCutOffByParams({ cutOffId });
+  if (!cutOff) {
+    throw new Error('El corte no existe.');
+  }
+};
+
+export const createCutOffSchema = [
+  body('userId')
+    .notEmpty().withMessage('El id del usuario es requerido.')
+    .isNumeric().withMessage('El id del usuario debe ser un número.'),
+  body('totalEntries')
+    .notEmpty().withMessage('El total de entradas es requerido.')
+    .isNumeric().withMessage('El total de entradas debe ser un número.'),
+  body('totalOutputs')
+    .notEmpty().withMessage('El total de salidas es requerido.')
+    .isNumeric().withMessage('El total de salidas debe ser un número.'),
+  body('totalCash')
+    .notEmpty().withMessage('El total de efectivo es requerido.')
+    .isNumeric().withMessage('El total de efectivo debe ser un número.'),
+];
+
+export const updateCutOffSchema = [
+  body('cutOffId')
+    .notEmpty().withMessage('El id es requerido.')
+    .isNumeric().withMessage('El id debe ser un número.')
+    .custom(existCutOff).withMessage('El corte no existe.')
+];

--- a/src/app/modules/storage/infrastructure/entities/cut-off.entity.ts
+++ b/src/app/modules/storage/infrastructure/entities/cut-off.entity.ts
@@ -1,0 +1,47 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn
+} from 'typeorm';
+
+import { UserEntity } from '@modules/users/infrastructure/entities/user.entity';
+
+export enum STATUS {
+  ACTIVO = 'ACTIVO',
+  ELIMINADO = 'ELIMINADO'
+}
+
+@Entity('cut_offs')
+export class CutOffEntity {
+  @PrimaryGeneratedColumn()
+  cutOffId!: number;
+
+  @ManyToOne(() => UserEntity, user => user.movements)
+  @JoinColumn({ name: 'userId' })
+  user!: UserEntity;
+
+  @Column({ type: 'decimal', precision: 10, scale: 2 })
+  totalEntries!: number;
+
+  @Column({ type: 'decimal', precision: 10, scale: 2 })
+  totalOutputs!: number;
+
+  @Column({ type: 'decimal', precision: 10, scale: 2 })
+  totalCash!: number;
+
+  @Column('date', { name: 'cutoff_date' })
+  cutoffDate!: Date;
+
+  @Column({ type: 'enum', enum: STATUS, default: STATUS.ACTIVO })
+  status!: string;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
+}

--- a/src/app/modules/storage/infrastructure/repositories/cut-off.repository.ts
+++ b/src/app/modules/storage/infrastructure/repositories/cut-off.repository.ts
@@ -1,0 +1,46 @@
+import CutOff from '../../domain/models/cut-off';
+import { CutOffEntity } from '../entities/cut-off.entity';
+
+import { BaseRepository } from '@app/core/bases/base.repository';
+import { ResponseInterface } from '@app/core/interfaces';
+
+class CutOffRepository extends BaseRepository<CutOffEntity> {
+  constructor() { super(CutOffEntity, 'cutOff'); }
+
+  async getCutOffsByParams(params: Record<string, any>): Promise<ResponseInterface<CutOffEntity>> {
+    const { page, limit, orderBy, ...filters } = params;
+
+    this.joinConfig = {
+      user: 'left'
+    };
+
+    return this.findAllByParams({
+      filters,
+      page,
+      limit,
+      orderBy,
+      forceJoins: ['user']
+    });
+  }
+
+  async getOneCutOffByParams(filters: Record<string, any>): Promise<CutOffEntity | null> {
+    this.joinConfig = {
+      user: 'left'
+    };
+
+    return this.findOneByParams({
+      filters,
+      forceJoins: ['user']
+    });
+  }
+
+  async createCutOff(cutOff: CutOff): Promise<CutOffEntity> {
+    const params = cutOff.toJSON();
+
+    this.repository.create({ ...params, user: { userId: params.userId } });
+    return this.repository.save(params);
+  }
+}
+
+const cutOffRepository = new CutOffRepository();
+export default cutOffRepository;

--- a/src/app/modules/storage/services/cut-off.service.ts
+++ b/src/app/modules/storage/services/cut-off.service.ts
@@ -1,0 +1,38 @@
+import { Request, Response, NextFunction } from 'express';
+import { RequestHandler } from '@core/bases/base.services';
+import { Cacheable, InvalidateCache } from '@libs/cacheable';
+
+import CutOff from '../domain/models/cut-off';
+import cutOffRepository from '../infrastructure/repositories/cut-off.repository';
+
+export default class CutOffService {
+  @RequestHandler
+  @Cacheable({ keyPrefix: 'cut-offs', ttl: 60 })
+  static async getCutOffs(this: void, req: Request, res: Response, next: NextFunction) {
+    const { data, total } = await cutOffRepository.getCutOffsByParams(req.query);
+    return { data, total };
+  }
+
+  @RequestHandler
+  @Cacheable({ keyPrefix: 'cut-offs', idParam: 'cutOffId', ttl: 60 })
+  static async getOneCutOff(this: void, req: Request, res: Response, next: NextFunction) {
+    const cutOff = await cutOffRepository.getOneCutOffByParams(req.query);
+    return cutOff;
+  }
+
+  @RequestHandler
+  @InvalidateCache({ keys: ['cut-offs'] })
+  static async cutOffRegister(this: void, req: Request, res: Response, next: NextFunction) {
+    const cutOff = new CutOff(req.body);
+    const result = await cutOffRepository.createCutOff(cutOff);
+    return result;
+  }
+
+  @RequestHandler
+  @InvalidateCache({ keys: ['cut-offs'] })
+  static async cutOffUpdate(this: void, req: Request, res: Response, next: NextFunction) {
+    const cutOff = new CutOff(req.body);
+    const result = await cutOffRepository.createCutOff(cutOff);
+    return result;
+  }
+}

--- a/src/app/modules/users/infrastructure/entities/user.entity.ts
+++ b/src/app/modules/users/infrastructure/entities/user.entity.ts
@@ -6,6 +6,7 @@ import { UserSessionEntity } from "./user-session.entity";
 import { BusinessUnitEntity } from "./business-unit.entity";
 import { ProductEntity } from "@modules/storage/infrastructure/entities/product.entity";
 import { ProductMovementEntity } from "@modules/storage/infrastructure/entities/product-movement.entity";
+import { CutOffEntity } from "@modules/storage/infrastructure/entities/cut-off.entity";
 
 export enum STATUS {
   ACTIVO = "ACTIVO",
@@ -72,6 +73,9 @@ export class UserEntity {
 
   @OneToMany(() => ProductMovementEntity, (movement) => movement.user)
   movements!: ProductMovementEntity[];
+
+  @OneToMany(() => CutOffEntity, (cutOff) => cutOff.user)
+  cutOffs!: CutOffEntity[];
 
   @OneToMany(() => ProductEntity, product => product.createdBy)
   products?: ProductEntity[];

--- a/src/app/routes/storage/cut-off.routes.ts
+++ b/src/app/routes/storage/cut-off.routes.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+import { validate } from '@middlewares/validator.middleware';
+
+import CutOffService from '@modules/storage/services/cut-off.service';
+import { createCutOffSchema, updateCutOffSchema } from '@modules/storage/domain/validator/cut-off.validator';
+
+const cutOffRouter = Router();
+
+cutOffRouter.get('/', CutOffService.getCutOffs as any);
+cutOffRouter.get('/unique', CutOffService.getOneCutOff as any);
+cutOffRouter.post('/', validate(createCutOffSchema), CutOffService.cutOffRegister as any);
+cutOffRouter.put('/', validate(updateCutOffSchema), CutOffService.cutOffUpdate as any);
+
+export default cutOffRouter;

--- a/src/app/routes/storage/index.ts
+++ b/src/app/routes/storage/index.ts
@@ -2,10 +2,12 @@ import { Router } from "express";
 
 import productRouter from "./product.routes";
 import productMovementRouter from "./product-movement.routes";
+import cutOffRouter from "./cut-off.routes";
 
 const storageRouter = Router();
 
 storageRouter.use("/products", productRouter);
 storageRouter.use("/product-movements", productMovementRouter);
+storageRouter.use("/cut-offs", cutOffRouter);
 
 export default storageRouter;


### PR DESCRIPTION
## Summary
- add cut-off domain model and validator
- add database entity and repository for cut-offs
- implement service and routes for cut-offs
- register cut-off routes in storage
- relate cut-offs with users

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685e212480988330aa99ee601ea361b5